### PR TITLE
Use rollup plugin to exclude peer dependencies from build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "lit": "^3.1.4",
-        "ol-mapbox-style": "^12.5.0"
+        "lit": "^3.1.4"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.4",
@@ -29,13 +28,15 @@
         "lint-staged": "^15.2.7",
         "playwright": "^1.50.1",
         "prettier": "^3.5.2",
+        "rollup-plugin-peer-deps-external": "^2.2.4",
         "storybook": "^8.5.8",
         "typescript": "^5.7.3",
         "vite": "^6.1.1",
         "vitest": "^3.0.6"
       },
       "peerDependencies": {
-        "ol": "^10.4.0"
+        "ol": "^10.4.0",
+        "ol-mapbox-style": "^12.5.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1049,6 +1050,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
       "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1057,13 +1059,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
       "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
       "version": "23.1.0",
       "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-23.1.0.tgz",
       "integrity": "sha512-R6/ihEuC5KRexmKIYkWqUv84Gm+/QwsOUgHyt1yy2XqCdGdLvlBWVWIIeTZWN4NGdwmY6xDzdSGU2R9oBLNg2w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
@@ -5800,7 +5804,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -6313,7 +6318,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-3.0.2.tgz",
       "integrity": "sha512-o1vqooDELinvNkLBIdrBVUtuxwhNeYPOp/7LRrSxPYzmZ9aTYEuObrFoQzH6Gn3nv7t1nkyIbj5FcbX41FbSyg==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -6420,6 +6426,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6670,6 +6677,7 @@
       "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-12.5.0.tgz",
       "integrity": "sha512-Wr06OhV+tHlNZzol4C3bbKwcyHjNTb+ThMa3ALRRIMKosZ8z8m6A4KyX19zfNq9TI70LugEtMa5FVR7l7BlQVw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^23.1.0",
         "mapbox-to-css-font": "^3.0.2"
@@ -7343,7 +7351,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/rbush": {
       "version": "4.0.1",
@@ -7654,6 +7663,16 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-peer-deps-external": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
+      "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "rollup": "*"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7682,7 +7701,8 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/safaridriver": {
       "version": "1.0.0",
@@ -8379,7 +8399,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/tinyrainbow": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "storybook:build": "storybook build"
   },
   "dependencies": {
-    "lit": "^3.1.4",
-    "ol-mapbox-style": "^12.5.0"
+    "lit": "^3.1.4"
   },
   "peerDependencies": {
-    "ol": "^10.4.0"
+    "ol": "^10.4.0",
+    "ol-mapbox-style": "^12.5.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.4",
@@ -57,6 +57,7 @@
     "lint-staged": "^15.2.7",
     "playwright": "^1.50.1",
     "prettier": "^3.5.2",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
     "storybook": "^8.5.8",
     "typescript": "^5.7.3",
     "vite": "^6.1.1",

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,16 +4,16 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import https from 'node:https';
 import { defineConfig, loadEnv } from 'vite';
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-const externalRegEx = /(ol|ol-mapbox-style)(\/.+)?$/;
 
 export default ({ mode }) => {
   const env = { ...process.env, ...loadEnv(mode, process.cwd(), '') };
 
   // https://vitejs.dev/config/
   const config = defineConfig({
+    plugins: [peerDepsExternal()],
     build: {
       minify: false,
       lib: {
@@ -21,15 +21,6 @@ export default ({ mode }) => {
         name: 'yio-map',
         fileName: 'yio-map',
         formats: ['es'],
-      },
-      rollupOptions: {
-        external: id => externalRegEx.test(id),
-        output: {
-          globals: id =>
-            externalRegEx.test(id)
-              ? id.replace(/\.js$/, '').split('/').join('.')
-              : id,
-        },
       },
     },
     test: {


### PR DESCRIPTION
Less configuration, one thing less to worry about.