### PR TITLE
Content map

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
     <yio-map
       id="demo"
       center="[15.4956,48.8486]"
+      contentMap="/api/v2/pip/tiles/resources/style.json"
       zoom="13.9"
       class="map"
     ></yio-map>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   <body>
     <yio-map
       id="demo"
-      center="[15.4956,48.8486]"
+      center="[14.2245,48.5504]"
       contentMap="/api/v2/pip/tiles/resources/style.json"
       zoom="13.9"
       class="map"

--- a/src/YioMap.js
+++ b/src/YioMap.js
@@ -28,6 +28,7 @@ export class YioMap extends LitElement {
   static properties = {
     center: { type: Array, reflect: true },
     zoom: { type: Number, reflect: true },
+    contentMap: { type: String },
     userSelect: { attribute: false },
   };
 
@@ -36,6 +37,11 @@ export class YioMap extends LitElement {
 
   /** @type {Map} */
   #map = null;
+
+  /**
+   * @type {string} Mapbox / MapLibre style, or URL to style
+   */
+  #contentMap = '';
 
   /** @type {LayerGroup} */
   #contentLayer = new LayerGroup();
@@ -54,17 +60,31 @@ export class YioMap extends LitElement {
     return this.#contentLayer;
   }
 
+  set contentMap(value) {
+    this.#contentMap = value;
+    this.#applyContentMap();
+  }
+
+  get contentMap() {
+    return this.#contentMap;
+  }
+
+  #applyContentMap() {
+    if (this.#map && this.#contentLayer) {
+      apply(this.#contentLayer, this.contentMap).catch(error => {
+        console.error(error);
+      });
+    }
+  }
+
   #createMap() {
     this.#map = new Map();
     this.#map.addControl(new LayerControl({ map: this.#map }));
 
+    if (this.contentMap) {
+      this.#applyContentMap();
+    }
     this.#map.addLayer(this.#contentLayer);
-    apply(this.#contentLayer, '/api/v2/pip/tiles/resources/style.json').catch(
-      error => {
-        console.error(error);
-      },
-    );
-
     this.#map.addInteraction(
       new UserSelectInteraction({
         yioMap: this,

--- a/src/YioMap.js
+++ b/src/YioMap.js
@@ -71,9 +71,13 @@ export class YioMap extends LitElement {
 
   #applyContentMap() {
     if (this.#map && this.#contentLayer) {
-      apply(this.#contentLayer, this.contentMap).catch(error => {
-        console.error(error);
-      });
+      if (this.contentMap) {
+        apply(this.#contentLayer, this.contentMap).catch(error => {
+          console.error(error);
+        });
+      } else {
+        this.#contentLayer.getLayers().clear();
+      }
     }
   }
 

--- a/stories/FiberMap.stories.js
+++ b/stories/FiberMap.stories.js
@@ -60,17 +60,6 @@ export const ContentMap = {
               {
                 type: 'Feature',
                 geometry: {
-                  type: 'LineString',
-                  coordinates: [
-                    [-74.01, 40.7128],
-                    [-74.005, 40.7158],
-                  ],
-                },
-                properties: { color: '#0000ff' },
-              },
-              {
-                type: 'Feature',
-                geometry: {
                   type: 'Point',
                   coordinates: [-74.003, 40.7148],
                 },
@@ -81,15 +70,6 @@ export const ContentMap = {
         },
       },
       layers: [
-        {
-          id: 'polygon-layer',
-          type: 'fill',
-          source: 'simple-features',
-          paint: {
-            'fill-color': '#ff0000',
-            'fill-opacity': 0.5,
-          },
-        },
         {
           id: 'line-layer',
           type: 'line',

--- a/stories/FiberMap.stories.js
+++ b/stories/FiberMap.stories.js
@@ -27,3 +27,88 @@ export const CenterAndZoomArguments = {
     zoom: 12,
   },
 };
+
+/** @type {import('@storybook/web-components').StoryObj} */
+export const ContentMap = {
+  args: {
+    center: [-73.9978486645436, 40.7155],
+    zoom: 15,
+    contentMap: {
+      version: 8,
+      sources: {
+        'simple-features': {
+          type: 'geojson',
+          data: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                geometry: {
+                  type: 'Polygon',
+                  coordinates: [
+                    [
+                      [-74.006, 40.7128],
+                      [-74.001, 40.7128],
+                      [-74.001, 40.7178],
+                      [-74.006, 40.7178],
+                      [-74.006, 40.7128],
+                    ],
+                  ],
+                },
+                properties: { color: '#ff0000' },
+              },
+              {
+                type: 'Feature',
+                geometry: {
+                  type: 'LineString',
+                  coordinates: [
+                    [-74.01, 40.7128],
+                    [-74.005, 40.7158],
+                  ],
+                },
+                properties: { color: '#0000ff' },
+              },
+              {
+                type: 'Feature',
+                geometry: {
+                  type: 'Point',
+                  coordinates: [-74.003, 40.7148],
+                },
+                properties: { color: '#00ff00' },
+              },
+            ],
+          },
+        },
+      },
+      layers: [
+        {
+          id: 'polygon-layer',
+          type: 'fill',
+          source: 'simple-features',
+          paint: {
+            'fill-color': '#ff0000',
+            'fill-opacity': 0.5,
+          },
+        },
+        {
+          id: 'line-layer',
+          type: 'line',
+          source: 'simple-features',
+          paint: {
+            'line-color': '#0000ff',
+            'line-width': 2,
+          },
+        },
+        {
+          id: 'point-layer',
+          type: 'circle',
+          source: 'simple-features',
+          paint: {
+            'circle-radius': 6,
+            'circle-color': '#00ff00',
+          },
+        },
+      ],
+    },
+  },
+};

--- a/test/fiber-map.test.js
+++ b/test/fiber-map.test.js
@@ -69,4 +69,34 @@ describe('YioMap', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(onclick).toHaveBeenCalled();
   });
+
+  it('creates content layer with mapbox style', async () => {
+    /** @type {import('../src/YioMap.js').YioMap} */
+    const el = await fixture('<yio-map tabindex="0"></yio-map>');
+    el.contentMap = JSON.stringify({
+      version: 8,
+      sources: {
+        'simple-features': {
+          type: 'geojson',
+          data: {
+            type: 'FeatureCollection',
+            features: [],
+          },
+        },
+      },
+      layers: [
+        {
+          id: 'point-layer',
+          source: 'simple-features',
+        },
+      ],
+    });
+
+    const numberOfContentLayers = await new Promise(resolve => {
+      setTimeout(() => {
+        resolve(el._getContentLayer().getLayers().getLength());
+      }, 0);
+    });
+    expect(numberOfContentLayers).to.be.greaterThan(0);
+  });
 });


### PR DESCRIPTION
This PR implements the content map with mapbox/maplibre styles, as defined in #13. The changes of the `contentMap`-property are handled in a `setter`-function. A story showcasing this feature and a simple test have been added.

