### PR TITLE
always clear content layer

### DIFF
--- a/src/YioMap.js
+++ b/src/YioMap.js
@@ -71,12 +71,11 @@ export class YioMap extends LitElement {
 
   #applyContentMap() {
     if (this.#map && this.#contentLayer) {
+      this.#contentLayer.getLayers().clear();
       if (this.contentMap) {
         apply(this.#contentLayer, this.contentMap).catch(error => {
           console.error(error);
         });
-      } else {
-        this.#contentLayer.getLayers().clear();
       }
     }
   }


### PR DESCRIPTION
With the PR, the `contentLayer` is always cleared when a new mapbox/maplibre style is set, as `apply` of `ol-mapbox-style` adds new layers, instead of replacing them.