### PR TITLE
edit mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,13 +37,31 @@
       class="map"
     ></yio-map>
     <div id="info"></div>
+
+    <label for="mode-select">Mode:</label>
+    <select id="mode-select">
+      <option value="select">Select</option>
+      <option value="edit">Edit</option>
+    </select>
+
     <script>
       const map = document.getElementById('demo');
       const info = document.getElementById('info');
+
+      const interactionSelect = document.getElementById('mode-select');
+
+      interactionSelect.addEventListener('change', function () {
+        if (this.value === 'edit') {
+          map.setAttribute('editLayer', 'sites');
+        } else {
+          map.removeAttribute('editLayer');
+        }
+      });
       map.addEventListener('pointermove', () => {
         info.style.display = 'none';
       });
       map.addEventListener('click', e => {
+        console.log(e);
         const item = e.target.userSelect[0];
         info.style.display = item ? 'block' : 'none';
         if (!item) {

--- a/src/YioMap.js
+++ b/src/YioMap.js
@@ -3,11 +3,14 @@ import style from 'ol/ol.css?inline';
 import layerControlStyle from './controls/LayerControl.css?inline';
 
 import Map from 'ol/Map.js';
+import GeoJSON from 'ol/format/GeoJSON.js';
 import { fromLonLat, toLonLat } from 'ol/proj.js';
 import LayerControl from './controls/LayerControl.js';
 import UserSelectInteraction from './controls/UserSelectInteraction.js';
+import UserEditInteraction from './controls/UserEditInteraction.js';
 import LayerGroup from 'ol/layer/Group.js';
 import apply from 'ol-mapbox-style';
+import { getLayerForMapboxSourceLayer } from './utils.js';
 
 export class YioMap extends LitElement {
   static styles = [
@@ -29,6 +32,7 @@ export class YioMap extends LitElement {
     center: { type: Array, reflect: true },
     zoom: { type: Number, reflect: true },
     contentMap: { type: String },
+    editLayer: { type: String },
     userSelect: { attribute: false },
   };
 
@@ -43,8 +47,23 @@ export class YioMap extends LitElement {
    */
   #contentMap = '';
 
+  /**
+   * @type {string} Mapbox / Maplibre source layer name
+   */
+  #editLayer = null;
+
   /** @type {LayerGroup} */
   #contentLayer = new LayerGroup();
+
+  /**
+   * @type {UserEditInteraction}
+   */
+  #userEditInteraction = null;
+
+  /**
+   * @type {UserSelectInteraction}
+   */
+  #userSelectInteraction = null;
 
   constructor() {
     super();
@@ -69,30 +88,91 @@ export class YioMap extends LitElement {
     return this.#contentMap;
   }
 
+  set editLayer(value) {
+    const oldValue = this.#editLayer;
+    this.#editLayer = value;
+    if (!this.#userEditInteraction) {
+      return;
+    }
+    if (!value && oldValue) {
+      // when the editlayer-attribute is removed, the edit source is cleared.
+      // re-fetch all tiles, the new changes are supposed to be ready on the server.
+      const hadEdits = this.#userEditInteraction.clearEditSource();
+      if (hadEdits) {
+        getLayerForMapboxSourceLayer(this._getContentLayer(), oldValue);
+      }
+    }
+    this.#handleEditLayerChange();
+  }
+
+  get editLayer() {
+    return this.#editLayer;
+  }
+
+  #handleEditLayerChange() {
+    if (!this.#userEditInteraction) {
+      return;
+    }
+    this.#userSelectInteraction.setActive(!this.editLayer);
+    this.#userEditInteraction.setActive(!!this.editLayer);
+  }
+
+  get editFeatures() {
+    const features = this.#userEditInteraction
+      .getEditLayer()
+      .getSource()
+      .getFeatures();
+    const geojsonFormat = new GeoJSON();
+
+    return geojsonFormat.writeFeaturesObject(features, {
+      dataProjection: 'EPSG:4326',
+      featureProjection: 'EPSG:3857',
+    });
+  }
+
   #applyContentMap() {
     if (this.#map && this.#contentLayer) {
       this.#contentLayer.getLayers().clear();
+      const editOlLayer =
+        this.#userEditInteraction && this.#userEditInteraction.getEditLayer();
+      editOlLayer.getSource().clear();
+
       if (this.contentMap) {
-        apply(this.#contentLayer, this.contentMap).catch(error => {
-          console.error(error);
-        });
+        apply(this.#contentLayer, this.contentMap)
+          .then(() => {
+            // check state of attributes that need the contentLayer
+            this.#handleEditLayerChange();
+          })
+          .catch(error => {
+            console.error(error);
+          });
       }
     }
   }
 
+  /**
+   * creates the map instance and essential layers and interactions
+   */
   #createMap() {
     this.#map = new Map();
     this.#map.addControl(new LayerControl({ map: this.#map }));
 
+    this.#map.addLayer(this.#contentLayer);
+
+    this.#userEditInteraction = new UserEditInteraction({
+      yioMap: this,
+      map: this.#map,
+    });
+    this.#userSelectInteraction = new UserSelectInteraction({
+      yioMap: this,
+    });
+
+    this.#map.addInteraction(this.#userEditInteraction);
+    this.#map.addInteraction(this.#userSelectInteraction);
+
     if (this.contentMap) {
       this.#applyContentMap();
     }
-    this.#map.addLayer(this.#contentLayer);
-    this.#map.addInteraction(
-      new UserSelectInteraction({
-        yioMap: this,
-      }),
-    );
 
     let firstMove = true;
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,20 @@
+import { Circle, Fill, Stroke, Style } from 'ol/style.js';
+
+const fill = new Fill({
+  color: 'rgba(255,255,255,0.4)',
+});
+const stroke = new Stroke({
+  color: '#3399CC',
+  width: 1.25,
+});
+export const defaultStyles = [
+  new Style({
+    image: new Circle({
+      fill: fill,
+      stroke: stroke,
+      radius: 5,
+    }),
+    fill: fill,
+    stroke: stroke,
+  }),
+];

--- a/src/controls/UserEditInteraction.js
+++ b/src/controls/UserEditInteraction.js
@@ -10,15 +10,11 @@ import { getLayerForMapboxSourceLayer } from '../utils.js';
 /**
  * @typedef {Object} Options
  * @property {import('../YioMap.js').YioMap} yioMap
- * @property {import('ol/Map.js').default} map ol map
  */
 
 export default class UserSelectInteraction extends Interaction {
   /** @type {import('../YioMap.js').YioMap} */
   #yioMap = null;
-
-  /** @type {import('ol/Map.js').default} */
-  #map = null;
 
   /**
    * @type {VectorLayer} layer for temporary features of the draw / modify interactions
@@ -60,7 +56,6 @@ export default class UserSelectInteraction extends Interaction {
   constructor(options) {
     super();
     this.#yioMap = options.yioMap;
-    this.#map = options.map;
 
     this.#editLayer = new VectorLayer({
       source: new VectorSource({
@@ -123,8 +118,8 @@ export default class UserSelectInteraction extends Interaction {
     }
     this.#editLayer.setMap(map);
     super.setMap(map);
-    this.modifyInteraction.setMap(this.#map);
-    this.drawInteraction.setMap(this.#map);
+    this.modifyInteraction.setMap(map);
+    this.drawInteraction.setMap(map);
   }
 
   drawInteraction;
@@ -153,7 +148,7 @@ export default class UserSelectInteraction extends Interaction {
     );
     if (active) {
       this.#editSourceLayer = sourceLayer;
-      this.#originalStyle = sourceLayer.getStyle();
+      this.#originalStyle = sourceLayer?.getStyle();
       sourceLayer.setStyle((feature, resolution) => {
         if (this.#modifiedFeatureIDs.includes(feature.get('id'))) {
           return;

--- a/src/controls/UserEditInteraction.js
+++ b/src/controls/UserEditInteraction.js
@@ -1,0 +1,227 @@
+import Interaction from 'ol/interaction/Interaction.js';
+import VectorLayer from 'ol/layer/Vector.js';
+import RenderFeature, { toFeature } from 'ol/render/Feature.js';
+import VectorSource from 'ol/source/Vector.js';
+import Draw from 'ol/interaction/Draw.js';
+import Modify from 'ol/interaction/Modify.js';
+import { defaultStyles } from '../constants.js';
+import { getLayerForMapboxSourceLayer } from '../utils.js';
+
+/**
+ * @typedef {Object} Options
+ * @property {import('../YioMap.js').YioMap} yioMap
+ * @property {import('ol/Map.js').default} map ol map
+ */
+
+export default class UserSelectInteraction extends Interaction {
+  /** @type {import('../YioMap.js').YioMap} */
+  #yioMap = null;
+
+  /** @type {import('ol/Map.js').default} */
+  #map = null;
+
+  /**
+   * @type {VectorLayer} layer for temporary features of the draw / modify interactions
+   */
+  #editLayer = null;
+
+  getEditLayer() {
+    return this.#editLayer;
+  }
+
+  /**
+   * clears the source of the edit layer, containing newly drawn and modified features
+   * @returns {boolean} true if features were cleared
+   */
+  clearEditSource() {
+    const source = this.#editLayer.getSource();
+    if (source.getFeatures().length) {
+      this.#editLayer.getSource().clear();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * ol layer connected associated with the given mapbox `source-layer` (editLayer)
+   * @type {VectorLayer | import("ol/layer/VectorTile.js").default}
+   */
+  #editSourceLayer;
+
+  /**
+   * IDs of features that were modified
+   * @type {Array<string | number>}
+   */
+  #modifiedFeatureIDs = [];
+
+  /**
+   * @param {Options} options
+   */
+  constructor(options) {
+    super();
+    this.#yioMap = options.yioMap;
+    this.#map = options.map;
+
+    this.#editLayer = new VectorLayer({
+      source: new VectorSource({
+        features: [],
+      }),
+    });
+
+    this.drawInteraction = new Draw({
+      source: this.#editLayer.getSource(),
+      condition: event => {
+        const existingFeature = event.map
+          .getFeaturesAtPixel(event.pixel)
+          .find(f => {
+            return f.get('layer') === this.#yioMap.editLayer;
+          });
+        return !existingFeature;
+      },
+      type: 'Point',
+    });
+    this.drawInteraction.on('drawend', event => {
+      const feature = event.feature;
+      feature.set('layer', this.#yioMap.editLayer);
+      this.#editLayer.getSource().once('addfeature', () => {
+        this.#handleClick(event);
+      });
+    });
+    this.modifyInteraction = new Modify({
+      source: this.#editLayer.getSource(),
+    });
+
+    this.modifyInteraction.on('modifystart', event => {
+      const modifiedFeatureIds = event.features
+        .getArray()
+        .map(feature => feature.get('id'))
+        .filter(id => !!id);
+      if (modifiedFeatureIds.length) {
+        for (let i = 0, ii = modifiedFeatureIds.length; i < ii; i++) {
+          const modifiedFeatureId = modifiedFeatureIds[i];
+          if (!this.#modifiedFeatureIDs.includes(modifiedFeatureId)) {
+            this.#modifiedFeatureIDs.push(modifiedFeatureId);
+          }
+        }
+        this.#editSourceLayer.changed();
+      }
+    });
+    this.modifyInteraction.on('modifyend', event => {
+      this.#handleClick(event);
+    });
+    this.drawInteraction.setActive(false);
+    this.modifyInteraction.setActive(false);
+  }
+
+  setMap(map) {
+    const currentMap = this.getMap();
+    if (currentMap) {
+      currentMap.removeLayer(this.#editLayer);
+    }
+    if (!map) {
+      return;
+    }
+    this.#editLayer.setMap(map);
+    super.setMap(map);
+    this.modifyInteraction.setMap(this.#map);
+    this.drawInteraction.setMap(this.#map);
+  }
+
+  drawInteraction;
+
+  modifyInteraction;
+
+  /**
+   * @param {import('ol/MapBrowserEvent.js').default} event
+   */
+  #handleClick(event) {
+    this.#yioMap.dispatchEvent(new PointerEvent('click', event.originalEvent));
+  }
+
+  /**
+   * original style of the content layer
+   */
+  #originalStyle = null;
+
+  setActive(active) {
+    if (!this.modifyInteraction || !this.drawInteraction) {
+      return;
+    }
+    const sourceLayer = getLayerForMapboxSourceLayer(
+      this.#yioMap._getContentLayer(),
+      this.#yioMap.editLayer,
+    );
+    if (active) {
+      this.#editSourceLayer = sourceLayer;
+      this.#originalStyle = sourceLayer.getStyle();
+      sourceLayer.setStyle((feature, resolution) => {
+        if (this.#modifiedFeatureIDs.includes(feature.get('id'))) {
+          return;
+        }
+        return this.#originalStyle(feature, resolution);
+      });
+      this.#setStyle();
+    } else {
+      if (this.#originalStyle) {
+        this.#editSourceLayer.setStyle(this.#originalStyle);
+      }
+      this.#editSourceLayer = null;
+    }
+    this.modifyInteraction.setActive(active);
+    this.drawInteraction.setActive(active);
+    this.#editLayer.getSource().clear();
+    super.setActive(active);
+  }
+
+  /**
+   * sets the style of the editing layer to match the existing layer of the content map.
+   */
+  #setStyle() {
+    this.#editLayer.setStyle((feature, resolution) => {
+      return this.#originalStyle(feature, resolution) || defaultStyles;
+    });
+  }
+
+  /**
+   * @param {import('ol/MapBrowserEvent.js').default} event
+   * @returns {boolean}
+   */
+  handleEvent(event) {
+    let propagateEvent = true;
+
+    if (event.type === 'click') {
+      const map = this.getMap();
+      const existingFeature = map.getFeaturesAtPixel(event.pixel).find(f => {
+        return (
+          f.getGeometry().getType() === 'Point' &&
+          f.get('layer') === this.#yioMap.editLayer
+        );
+      });
+
+      if (existingFeature) {
+        const existingFeatureId = existingFeature.get('id');
+        if (!this.#modifiedFeatureIDs.includes(existingFeatureId)) {
+          this.#modifiedFeatureIDs.push(existingFeatureId);
+        }
+        this.#editSourceLayer.changed();
+        let newFeature;
+        if (existingFeature instanceof RenderFeature) {
+          newFeature = toFeature(existingFeature);
+        } else {
+          newFeature = existingFeature.clone();
+        }
+        this.#editLayer.getSource().addFeature(newFeature);
+        this.#handleClick(event);
+        return false;
+      }
+    }
+
+    if (!this.drawInteraction.handleEvent(event)) {
+      propagateEvent = false;
+    }
+    if (propagateEvent && !this.modifyInteraction.handleEvent(event)) {
+      propagateEvent = false;
+    }
+    return propagateEvent;
+  }
+}

--- a/src/controls/UserSelectInteraction.js
+++ b/src/controls/UserSelectInteraction.js
@@ -1,6 +1,6 @@
 import Interaction from 'ol/interaction/Interaction.js';
 import VectorLayer from 'ol/layer/Vector.js';
-import { toFeature } from 'ol/render/Feature.js';
+import RenderFeature, { toFeature } from 'ol/render/Feature.js';
 import VectorSource from 'ol/source/Vector.js';
 
 /**
@@ -67,8 +67,11 @@ export default class UserSelectInteraction extends Interaction {
     userSelectSource.clear();
     userSelectSource.addFeatures(
       features.map(
-        /** @param {import('ol/render/Feature.js').default} renderFeature */
-        renderFeature => toFeature(renderFeature),
+        /** @param {import('ol/render/Feature.js').default} featureOrRenderFeature */
+        featureOrRenderFeature =>
+          featureOrRenderFeature instanceof RenderFeature
+            ? toFeature(featureOrRenderFeature)
+            : featureOrRenderFeature,
       ),
     );
     this.#yioMap.notifyNextChange = true;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,32 @@
+import { getLayer } from 'ol-mapbox-style';
+import { Point } from 'ol/geom.js';
+import RenderFeature from 'ol/render/Feature.js';
+
+/**
+ * gets the ol layer for a given mapbox source-layer
+ * @param {import("ol/layer/Group.js").default} contentLayer
+ * @param {string} mapboxSourceLayer mapbox source layer id
+ * @returns {import("ol/layer/Vector.js").default | import("ol/layer/VectorTile.js").default}
+ */
+export function getLayerForMapboxSourceLayer(contentLayer, mapboxSourceLayer) {
+  if (!mapboxSourceLayer) {
+    return;
+  }
+  const styleDocument = contentLayer.get('mapbox-style');
+  if (!styleDocument) {
+    return;
+  }
+
+  const mapboxLayer = styleDocument.layers.find(l => {
+    return l['source-layer'] === mapboxSourceLayer;
+  });
+
+  if (!mapboxLayer) {
+    throw new Error(
+      `<yio-map>: Invalid value for "editLayer". Could not find "${mapboxSourceLayer}" as source-layer in the content map.`,
+    );
+  }
+  return /** @type {import("ol/layer/Vector.js").default | import("ol/layer/VectorTile.js").default} */ (
+    getLayer(contentLayer, mapboxLayer.id)
+  );
+}


### PR DESCRIPTION
implementation of #14

 - start editing by setting the `editLayer`-attribute to a `source-layer` of the defined `contentMap`
 - click to create a new point
 - click on an existing point and drag it to modify its position
 - modifications will fire a `click` event
 - the `editFeatures`-property provides a `GeoJSON` with all modified features
 - when the `editLayer`-attribute is removed, the temporary draw layer is removed and the original layer is refreshed


The current implementation status allows editing points of `VectorTile`-layers.